### PR TITLE
Fix missing command_exists helper

### DIFF
--- a/src/utils/terminal.sh
+++ b/src/utils/terminal.sh
@@ -14,5 +14,10 @@ clear() {
     fi
 }
 
+# Check if a command exists in PATH
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
 # Export functions
-export -f clear
+export -f clear command_exists


### PR DESCRIPTION
## Summary
- add command_exists helper function in terminal utilities

## Testing
- `bash test-fixes.sh`

------
https://chatgpt.com/codex/tasks/task_e_684053de2dac832a9d4c3e8fb3d56df6