### PR TITLE
Fix USB structure creation

### DIFF
--- a/src/deployment/usb_deploy.sh
+++ b/src/deployment/usb_deploy.sh
@@ -115,7 +115,7 @@ deploy_to_usb() {
     # Step 4: Create Leonardo structure
     echo ""
     echo -e "${CYAN}Creating Leonardo structure...${COLOR_RESET}"
-    if ! create_leonardo_structure; then
+    if ! create_leonardo_structure "$LEONARDO_USB_MOUNT"; then
         return 1
     fi
     

--- a/test-usb-deployment.sh
+++ b/test-usb-deployment.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # Test USB deployment functionality
 
-source leonardo.sh
+# Load only the utilities needed for this test
+source src/utils/colors.sh
+source src/utils/logging.sh
+source src/utils/filesystem.sh
+source src/usb/detector.sh
+source src/usb/manager.sh
+source src/deployment/usb_deploy.sh
+
+# Minimal logging setup
+export LEONARDO_LOG_DIR="/tmp"
+export LEONARDO_AUDIT_LOG=false
 
 echo -e "${CYAN}Testing USB Deployment Functions${COLOR_RESET}"
 echo "================================="
@@ -35,6 +45,20 @@ fi
 echo ""
 echo "4. Current USB drives:"
 list_usb_drives 2>/dev/null || echo -e "${YELLOW}No USB drives detected${COLOR_RESET}"
+
+echo ""
+echo "5. Testing directory creation under mount point..."
+tmp_dir=$(mktemp -d)
+export LEONARDO_USB_MOUNT="$tmp_dir"
+create_leonardo_structure "$LEONARDO_USB_MOUNT"
+
+if [[ -d "$LEONARDO_USB_MOUNT/leonardo/models" ]] && [[ -d "$LEONARDO_USB_MOUNT/leonardo/config" ]]; then
+    echo -e "${GREEN}✓ Directory tree created at $LEONARDO_USB_MOUNT${COLOR_RESET}"
+else
+    echo -e "${RED}✗ Directory tree not created under $LEONARDO_USB_MOUNT${COLOR_RESET}"
+fi
+
+rm -rf "$tmp_dir"
 
 echo ""
 echo -e "${DIM}Test complete${COLOR_RESET}"


### PR DESCRIPTION
## Summary
- ensure USB deployment passes mount point to `create_leonardo_structure`
- expand USB deployment test to verify directory tree creation

## Testing
- `bash test-usb-deployment.sh >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6840edf1ce64832aa79890a5f037ab8d