### PR TITLE
Improve USB deployment test script

### DIFF
--- a/test-usb-deployment.sh
+++ b/test-usb-deployment.sh
@@ -19,6 +19,12 @@ fi
 echo "2. Testing USB deployment function..."
 if command -v deploy_to_usb >/dev/null 2>&1; then
     echo -e "${GREEN}✓ deploy_to_usb function available${COLOR_RESET}"
+    # Invoke help or dry-run to ensure it executes without error
+    if deploy_to_usb --help >/dev/null 2>&1; then
+        echo -e "${GREEN}✓ deploy_to_usb --help succeeded${COLOR_RESET}"
+    else
+        echo -e "${RED}✗ deploy_to_usb --help failed${COLOR_RESET}"
+    fi
 else
     echo -e "${RED}✗ deploy_to_usb function not found${COLOR_RESET}"
 fi
@@ -35,6 +41,21 @@ fi
 echo ""
 echo "4. Current USB drives:"
 list_usb_drives 2>/dev/null || echo -e "${YELLOW}No USB drives detected${COLOR_RESET}"
+
+# Test 5: create_leonardo_structure with temporary directory
+echo ""
+echo "5. Testing create_leonardo_structure..."
+temp_dir=$(mktemp -d)
+if create_leonardo_structure "$temp_dir" >/dev/null 2>&1; then
+    if [[ -d "$temp_dir/leonardo/models" && -d "$temp_dir/leonardo/config" ]]; then
+        echo -e "${GREEN}✓ Directory structure created in temp dir${COLOR_RESET}"
+    else
+        echo -e "${RED}✗ Directory structure missing in temp dir${COLOR_RESET}"
+    fi
+else
+    echo -e "${RED}✗ create_leonardo_structure command failed${COLOR_RESET}"
+fi
+rm -rf "$temp_dir"
 
 echo ""
 echo -e "${DIM}Test complete${COLOR_RESET}"


### PR DESCRIPTION
## Summary
- test-usb-deployment.sh: add deploy_to_usb --help invocation
- assert create_leonardo_structure works in a temp dir

## Testing
- `bash -n test-usb-deployment.sh`
- `TERM=dumb LEONARDO_NO_COLOR=true bash test-usb-deployment.sh > /tmp/test_output2.txt`
- `tail -n 15 /tmp/test_output2.txt`

------
https://chatgpt.com/codex/tasks/task_e_6840fb800c18832a8c091d51c0b17cfd