### PR TITLE
Fix cross-platform USB formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,24 @@ cd LEO7
 # Follow the interactive setup!
 ```
 
+### Formatting a USB Drive
+
+Before installing Leonardo on a USB drive you can format it on **any** platform:
+
+```bash
+# Linux
+./leonardo.sh usb format /dev/sdX --format exfat --label LEONARDO
+
+# macOS
+diskutil eraseDisk ExFAT LEONARDO /dev/diskN
+
+# Windows (run in PowerShell)
+leonardo usb format 1 --format exfat --label LEONARDO
+```
+
+The Linux formatter now marks the partition as `msftdata`, ensuring the drive
+mounts correctly on macOS and Windows.
+
 ## 📋 Requirements
 
 ### Minimum System Requirements

--- a/leonardo.sh
+++ b/leonardo.sh
@@ -7813,6 +7813,13 @@ format_usb_drive() {
             if command_exists "parted"; then
                 parted -s "$device" mklabel gpt >/dev/null 2>&1
                 parted -s "$device" mkpart primary 0% 100% >/dev/null 2>&1
+                parted -s "$device" set 1 msftdata on >/dev/null 2>&1
+                if command_exists "partprobe"; then
+                    partprobe "$device" >/dev/null 2>&1
+                fi
+            else
+                log_message "ERROR" "parted is required to format USB drives"
+                return 1
             fi
             
             # Format partition

--- a/src/usb/manager.sh
+++ b/src/usb/manager.sh
@@ -108,6 +108,13 @@ format_usb_drive() {
             if command_exists "parted"; then
                 parted -s "$device" mklabel gpt >/dev/null 2>&1
                 parted -s "$device" mkpart primary 0% 100% >/dev/null 2>&1
+                parted -s "$device" set 1 msftdata on >/dev/null 2>&1
+                if command_exists "partprobe"; then
+                    partprobe "$device" >/dev/null 2>&1
+                fi
+            else
+                log_message "ERROR" "parted is required to format USB drives"
+                return 1
             fi
             
             # Format partition


### PR DESCRIPTION
## Summary
- add `msftdata` flag on Linux format to make USB readable on macOS and Windows
- mention formatting steps in README

## Testing
- `bash -n leonardo.sh`
- `bash -n src/usb/manager.sh`


------
https://chatgpt.com/codex/tasks/task_e_6841acc6f8c4832abdb742f2a233b2a8