### PR TITLE
Improve interactive menu usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,16 @@ cd LEO7
 # Run the installer
 ./leonardo.sh
 
+
 # Follow the interactive setup!
 ```
+
+### Navigating the Menus
+
+The installer uses a colorful text menu. Use the **arrow keys** or press a
+**number** to choose an option. The recommended item is always listed first so
+you can simply press **Enter** to accept it. Set `LEONARDO_DEBUG=true` if you
+need verbose output for troubleshooting.
 
 ### Formatting a USB Drive
 

--- a/src/ui/menu.sh
+++ b/src/ui/menu.sh
@@ -24,13 +24,15 @@ show_menu() {
     local num_options=${#options[@]}
     
     # Debug terminal detection
-    echo -e "${YELLOW}DEBUG: Terminal detection:${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - tty 0: $([[ -t 0 ]] && echo yes || echo no)${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - tty 1: $([[ -t 1 ]] && echo yes || echo no)${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - tty 2: $([[ -t 2 ]] && echo yes || echo no)${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - PS1: '${PS1:-}'${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - TERM: '${TERM:-}'${COLOR_RESET}" >&2
-    echo -e "${YELLOW}  - LEONARDO_FORCE_INTERACTIVE: '${LEONARDO_FORCE_INTERACTIVE:-}'${COLOR_RESET}" >&2
+    if [[ "${LEONARDO_DEBUG:-}" == "true" ]]; then
+        echo -e "${YELLOW}DEBUG: Terminal detection:${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - tty 0: $([[ -t 0 ]] && echo yes || echo no)${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - tty 1: $([[ -t 1 ]] && echo yes || echo no)${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - tty 2: $([[ -t 2 ]] && echo yes || echo no)${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - PS1: '${PS1:-}'${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - TERM: '${TERM:-}'${COLOR_RESET}" >&2
+        echo -e "${YELLOW}  - LEONARDO_FORCE_INTERACTIVE: '${LEONARDO_FORCE_INTERACTIVE:-}'${COLOR_RESET}" >&2
+    fi
     
     # Check for interactive terminal - more robust check
     local is_interactive=false
@@ -134,14 +136,15 @@ draw_menu() {
         echo -e "${GREEN}╚════════════════════════════════════════════╝${COLOR_RESET}" >/dev/tty
         echo >/dev/tty
         
-        # Display options
+        # Display options with numbering
         local i=1
         for option in "${options[@]}"; do
+            local display_option="${i}) ${option}"
             if [[ $i -eq $((selected + 1)) ]]; then
                 # Highlighted option
-                echo -e "${CYAN}▶ ${BRIGHT}${option}${COLOR_RESET}" >/dev/tty
+                echo -e "${CYAN}▶ ${BRIGHT}${display_option}${COLOR_RESET}" >/dev/tty
             else
-                echo -e "  ${DIM}${option}${COLOR_RESET}" >/dev/tty
+                echo -e "  ${DIM}${display_option}${COLOR_RESET}" >/dev/tty
             fi
             ((i++))
         done


### PR DESCRIPTION
## Summary
- gate terminal debug output behind `LEONARDO_DEBUG`
- number menu items for easier numeric navigation
- list recommended USB drives first when selecting a device
- document menu navigation and debug flag in README

## Testing
- `bash -n src/ui/menu.sh`
- `bash -n src/core/main.sh`
- `shellcheck src/ui/menu.sh src/core/main.sh`

------
https://chatgpt.com/codex/tasks/task_e_6840fda07ce8832a95b4641a9e956570