### PR TITLE
Fix macOS USB mounting

### DIFF
--- a/leonardo.sh
+++ b/leonardo.sh
@@ -7882,14 +7882,22 @@ mount_usb_drive() {
     
     case "$platform" in
         "macos")
-            # macOS auto-mounts, but we can force it
-            if ! diskutil mount "$device" >/dev/null 2>&1; then
-                log_message "ERROR" "Failed to mount device"
-                return 1
-            fi
-            
-            # Get actual mount point
+            # Check if already mounted
             LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$LEONARDO_USB_MOUNT" || "$LEONARDO_USB_MOUNT" == "not mounted" ]]; then
+                # Try mounting the whole disk first
+                if ! diskutil mountDisk "$device" >/dev/null 2>&1; then
+                    # Fallback to first partition (diskXs1)
+                    local part="${device}s1"
+                    if ! diskutil mount "$part" >/dev/null 2>&1; then
+                        log_message "ERROR" "Failed to mount device"
+                        return 1
+                    fi
+                    LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                else
+                    LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                fi
+            fi
             export LEONARDO_USB_MOUNT
             ;;
         "linux")
@@ -7955,7 +7963,7 @@ unmount_usb_drive() {
     
     case "$platform" in
         "macos")
-            if diskutil unmount "$device" >/dev/null 2>&1; then
+            if diskutil unmountDisk "$device" >/dev/null 2>&1 || diskutil unmount "${device}s1" >/dev/null 2>&1; then
                 log_message "INFO" "USB drive unmounted"
                 return 0
             fi


### PR DESCRIPTION
## Summary
- update macOS mount logic to check mount point and fall back to `mountDisk`
- use `unmountDisk` when unmounting on macOS

## Testing
- `bash test-fixes.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f354c718832aa73c510ec0b5ffa5