### PR TITLE
Fix macOS USB mount detection

### DIFF
--- a/leonardo.sh
+++ b/leonardo.sh
@@ -7752,6 +7752,11 @@ init_usb_device() {
     case "$platform" in
         "macos")
             LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$LEONARDO_USB_MOUNT" || "$LEONARDO_USB_MOUNT" =~ [Nn]ot\ mounted ]]; then
+                local part="$device"
+                [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            fi
             ;;
         "linux")
             # Try the device first
@@ -7882,14 +7887,22 @@ mount_usb_drive() {
     
     case "$platform" in
         "macos")
-            # macOS auto-mounts, but we can force it
-            if ! diskutil mount "$device" >/dev/null 2>&1; then
-                log_message "ERROR" "Failed to mount device"
-                return 1
-            fi
-            
-            # Get actual mount point
+            # Check if already mounted (partition or disk)
             LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$LEONARDO_USB_MOUNT" || "$LEONARDO_USB_MOUNT" =~ [Nn]ot\ mounted ]]; then
+                if ! diskutil mountDisk "$device" >/dev/null 2>&1; then
+                    local part="${device}s1"
+                    if ! diskutil mount "$part" >/dev/null 2>&1; then
+                        log_message "ERROR" "Failed to mount device"
+                        return 1
+                    fi
+                    LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                else
+                    local part="$device"
+                    [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                    LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                fi
+            fi
             export LEONARDO_USB_MOUNT
             ;;
         "linux")
@@ -7955,7 +7968,7 @@ unmount_usb_drive() {
     
     case "$platform" in
         "macos")
-            if diskutil unmount "$device" >/dev/null 2>&1; then
+            if diskutil unmountDisk "$device" >/dev/null 2>&1 || diskutil unmount "${device}s1" >/dev/null 2>&1; then
                 log_message "INFO" "USB drive unmounted"
                 return 0
             fi

--- a/src/usb/cli.sh
+++ b/src/usb/cli.sh
@@ -160,6 +160,11 @@ usb_cli_info() {
     case "$platform" in
         "macos")
             mount_point=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$mount_point" || "$mount_point" =~ [Nn]ot\ mounted ]]; then
+                local part="$device"
+                [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                mount_point=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            fi
             ;;
         "linux")
             mount_point=$(lsblk -no MOUNTPOINT "$device" 2>/dev/null | head -1)

--- a/src/usb/detector.sh
+++ b/src/usb/detector.sh
@@ -426,6 +426,11 @@ test_usb_write_speed() {
     case "$platform" in
         "macos")
             mount_point=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$mount_point" || "$mount_point" =~ [Nn]ot\ mounted ]]; then
+                local part="$device"
+                [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                mount_point=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            fi
             ;;
         "linux")
             mount_point=$(lsblk -no MOUNTPOINT "$device" 2>/dev/null | head -1)
@@ -478,6 +483,11 @@ is_leonardo_usb() {
     case "$platform" in
         "macos")
             mount_point=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$mount_point" || "$mount_point" =~ [Nn]ot\ mounted ]]; then
+                local part="$device"
+                [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                mount_point=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            fi
             ;;
         "linux")
             mount_point=$(lsblk -no MOUNTPOINT "$device" 2>/dev/null | grep -v "^$" | head -1)

--- a/src/usb/manager.sh
+++ b/src/usb/manager.sh
@@ -47,6 +47,11 @@ init_usb_device() {
     case "$platform" in
         "macos")
             LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$LEONARDO_USB_MOUNT" || "$LEONARDO_USB_MOUNT" =~ [Nn]ot\ mounted ]]; then
+                local part="$device"
+                [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            fi
             ;;
         "linux")
             # Try the device first
@@ -177,14 +182,22 @@ mount_usb_drive() {
     
     case "$platform" in
         "macos")
-            # macOS auto-mounts, but we can force it
-            if ! diskutil mount "$device" >/dev/null 2>&1; then
-                log_message "ERROR" "Failed to mount device"
-                return 1
-            fi
-            
-            # Get actual mount point
+            # Check if already mounted (partition or disk)
             LEONARDO_USB_MOUNT=$(diskutil info "$device" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+            if [[ -z "$LEONARDO_USB_MOUNT" || "$LEONARDO_USB_MOUNT" =~ [Nn]ot\ mounted ]]; then
+                if ! diskutil mountDisk "$device" >/dev/null 2>&1; then
+                    local part="${device}s1"
+                    if ! diskutil mount "$part" >/dev/null 2>&1; then
+                        log_message "ERROR" "Failed to mount device"
+                        return 1
+                    fi
+                    LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                else
+                    local part="$device"
+                    [[ ! "$device" =~ s[0-9]+$ ]] && part="${device}s1"
+                    LEONARDO_USB_MOUNT=$(diskutil info "$part" 2>/dev/null | grep "Mount Point:" | cut -d: -f2- | xargs)
+                fi
+            fi
             export LEONARDO_USB_MOUNT
             ;;
         "linux")
@@ -250,7 +263,7 @@ unmount_usb_drive() {
     
     case "$platform" in
         "macos")
-            if diskutil unmount "$device" >/dev/null 2>&1; then
+            if diskutil unmountDisk "$device" >/dev/null 2>&1 || diskutil unmount "${device}s1" >/dev/null 2>&1; then
                 log_message "INFO" "USB drive unmounted"
                 return 0
             fi


### PR DESCRIPTION
## Summary
- update init and mount logic to detect mount point from first partition on macOS
- extend CLI and detector scripts with the same fallback

## Testing
- `bash test-fixes.sh`

------
https://chatgpt.com/codex/tasks/task_e_6842f354c718832aa73c510ec0b5ffa5