### PR TITLE
Fix spinner style quoting

### DIFF
--- a/leonardo.sh
+++ b/leonardo.sh
@@ -2955,7 +2955,7 @@ declare -a SPINNER_STYLES=(
     "▁▂▃▄▅▆▇█▇▆▅▄▃▂"                    # Building blocks
     "⣾⣽⣻⢿⡿⣟⣯⣷"                    # Braille blocks
     "←↖↑↗→↘↓↙"                          # Arrows
-    "|/-\"                             # Classic
+    "|/-\\"                             # Classic
     "◢◣◤◥"                              # Triangles
     "⬒⬔⬓⬕"                              # Diamond
     "⠁⠂⠄⡀⢀⠠⠐⠈"                    # Dots

--- a/src/ui/progress.sh
+++ b/src/ui/progress.sh
@@ -194,7 +194,7 @@ declare -a SPINNER_STYLES=(
     "▁▂▃▄▅▆▇█▇▆▅▄▃▂"                    # Building blocks
     "⣾⣽⣻⢿⡿⣟⣯⣷"                    # Braille blocks
     "←↖↑↗→↘↓↙"                          # Arrows
-    "|/-\"                             # Classic
+    "|/-\\"                             # Classic
     "◢◣◤◥"                              # Triangles
     "⬒⬔⬓⬕"                              # Diamond
     "⠁⠂⠄⡀⢀⠠⠐⠈"                    # Dots


### PR DESCRIPTION
## Summary
- escape closing quote in spinner style string
- rebuild `leonardo.sh`

## Testing
- `bash assembly/build-simple.sh`
- `bash -n leonardo.sh`
- `bash test_search.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684597e1b51c832a9fcd8d812cb93d65